### PR TITLE
fix chapter names references

### DIFF
--- a/ch01/basic-gitops-operator/main.go
+++ b/ch01/basic-gitops-operator/main.go
@@ -14,7 +14,7 @@ func main() {
 	timerSec := 5 * time.Second
 	gitopsRepo := "https://github.com/PacktPublishing/ArgoCD-in-Practice.git"
 	localPath := "tmp/"
-	pathToApply := "ch1/basic-gitops-operator-config"
+	pathToApply := "ch01/basic-gitops-operator-config"
 	for {
 		fmt.Println("start repo sync")
 		err := syncRepo(gitopsRepo, localPath)

--- a/ch03/argocd-app.yaml
+++ b/ch03/argocd-app.yaml
@@ -10,7 +10,7 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: ch3/kustomize-installation
+    path: ch03/kustomize-installation
     repoURL: https://github.com/PacktPublishing/ArgoCD-in-Practice.git
     targetRevision: main
   syncPolicy:

--- a/ch03/disaster-recovery/backup-2021-09-15_18-16.yml
+++ b/ch03/disaster-recovery/backup-2021-09-15_18-16.yml
@@ -96,7 +96,7 @@ kind: Application
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"argoproj.io/v1alpha1","kind":"Application","metadata":{"annotations":{},"name":"argocd","namespace":"argocd"},"spec":{"destination":{"namespace":"argocd","server":"https://kubernetes.default.svc"},"project":"default","source":{"path":"ch3/kustomize-installation","repoURL":"https://github.com/PacktPublishing/ArgoCD-in-Practice.git","targetRevision":"main"},"syncPolicy":{"automated":{}}}}
+      {"apiVersion":"argoproj.io/v1alpha1","kind":"Application","metadata":{"annotations":{},"name":"argocd","namespace":"argocd"},"spec":{"destination":{"namespace":"argocd","server":"https://kubernetes.default.svc"},"project":"default","source":{"path":"ch03/kustomize-installation","repoURL":"https://github.com/PacktPublishing/ArgoCD-in-Practice.git","targetRevision":"main"},"syncPolicy":{"automated":{}}}}
   name: argocd
 spec:
   destination:
@@ -104,7 +104,7 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: ch3/kustomize-installation
+    path: ch03/kustomize-installation
     repoURL: https://github.com/PacktPublishing/ArgoCD-in-Practice.git
     targetRevision: main
   syncPolicy:
@@ -118,7 +118,7 @@ status:
     id: 0
     revision: 38f5370f7f0309fefaa53b75f65d373f824043be
     source:
-      path: ch3/kustomize-installation
+      path: ch03/kustomize-installation
       repoURL: https://github.com/PacktPublishing/ArgoCD-in-Practice.git
       targetRevision: main
   operationState:
@@ -644,7 +644,7 @@ status:
         version: v1
       revision: 38f5370f7f0309fefaa53b75f65d373f824043be
       source:
-        path: ch3/kustomize-installation
+        path: ch03/kustomize-installation
         repoURL: https://github.com/PacktPublishing/ArgoCD-in-Practice.git
         targetRevision: main
   reconciledAt: "2021-09-15T18:14:04Z"
@@ -982,7 +982,7 @@ status:
         namespace: argocd
         server: https://kubernetes.default.svc
       source:
-        path: ch3/kustomize-installation
+        path: ch03/kustomize-installation
         repoURL: https://github.com/PacktPublishing/ArgoCD-in-Practice.git
         targetRevision: main
     revision: 38f5370f7f0309fefaa53b75f65d373f824043be

--- a/ch04/kustomize-installation/argocd-app.yaml
+++ b/ch04/kustomize-installation/argocd-app.yaml
@@ -8,7 +8,7 @@ spec:
     server: https://kubernetes.default.svc 
   project: argocd 
   source: 
-    path: ch4/kustomize-installation 
+    path: ch04/kustomize-installation 
     repoURL: https://github.com/PacktPublishing/ArgoCD-in-Practice.git 
     targetRevision: main
   syncPolicy:

--- a/ch07/initial-setup/argocd-nonprod-app.yaml
+++ b/ch07/initial-setup/argocd-nonprod-app.yaml
@@ -8,7 +8,7 @@ spec:
     server: https://kubernetes.default.svc 
   project: default 
   source: 
-    path: ch7/initial-setup/argocd-nonprod
+    path: ch07/initial-setup/argocd-nonprod
     repoURL: https://github.com/PacktPublishing/ArgoCD-in-Practice.git 
     targetRevision: main
   syncPolicy:

--- a/ch07/initial-setup/argocd-platform-app.yaml
+++ b/ch07/initial-setup/argocd-platform-app.yaml
@@ -8,7 +8,7 @@ spec:
     server: https://kubernetes.default.svc 
   project: default 
   source: 
-    path: ch7/initial-setup/argocd-platform
+    path: ch07/initial-setup/argocd-platform
     repoURL: https://github.com/PacktPublishing/ArgoCD-in-Practice.git 
     targetRevision: main
   syncPolicy:

--- a/ch07/initial-setup/argocd-prod-app.yaml
+++ b/ch07/initial-setup/argocd-prod-app.yaml
@@ -8,7 +8,7 @@ spec:
     server: https://kubernetes.default.svc 
   project: default 
   source: 
-    path: ch7/initial-setup/argocd-prod
+    path: ch07/initial-setup/argocd-prod
     repoURL: https://github.com/PacktPublishing/ArgoCD-in-Practice.git 
     targetRevision: main
   syncPolicy:


### PR DESCRIPTION
Fixes:
- chapter name reference in a path values
- name of the backup file (ch03/disaster-recovery/backup-2021-09-15_18:16.yml) so that git clone on Windows could succeed (Windows doesn't support colon in path)